### PR TITLE
Update README.md lifecycle to 'Retired' badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+[![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 # sfts2s3
 Utility to move all files in a folder from BC Secure File Transfer Service to s3, once or cron. 


### PR DESCRIPTION
This PR does the following:
Change the lifestyle badge in the repo's README to 'Retired'

Testing instructions:

- Review the diff and check to see only the lifestyle badge was changed: https://github.com/bcgov/sfts2s3/compare/master...GDXDSD-5928-prep-for-archive#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5
- Review [README.md](https://github.com/bcgov/sfts2s3/blob/ccf187c0ec3ee81eccb917e8f97a777001d97199/README.md) to check that the 'Retired' lifestyle badge displays properly
- Click on the 'Retired' lifestyle badge in [README.md](https://github.com/bcgov/sfts2s3/blob/ccf187c0ec3ee81eccb917e8f97a777001d97199/README.md) to check and see if it links to: https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md