### PR TITLE
Update README.md with note about repo retirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 # sfts2s3
 Utility to move all files in a folder from BC Secure File Transfer Service to s3, once or cron. 
 
+## Notes
+This repo has been archived as it is currently not in use. Please see ticket https://apps.itsm.gov.bc.ca/jira/browse/GDXDSD-5928 for more information.
+
 ## Features
  
 * Move or copy files from sfts to s3

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 [![Lifecycle:Retired](https://img.shields.io/badge/Lifecycle-Retired-d45500)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 # sfts2s3
-Utility to move all files in a folder from BC Secure File Transfer Service to s3, once or cron. 
+> **:warning: Note:** This repo has been archived as it is currently not in use.
 
-## Notes
-This repo has been archived as it is currently not in use. Please see ticket https://apps.itsm.gov.bc.ca/jira/browse/GDXDSD-5928 for more information.
+Utility to move all files in a folder from BC Secure File Transfer Service to s3, once or cron. 
 
 ## Features
  


### PR DESCRIPTION
This PR does the following:
Adds note about repo retirement in [README.md](https://github.com/bcgov/sfts2s3/blob/GDXDSD-5928-2nd-prep-for-archive/README.md)

Testing instructions:

- Review the diff and check to see the only change was the addition of the warning section: https://github.com/bcgov/sfts2s3/compare/GDXDSD-5928-2nd-prep-for-archive?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5
- Review [README.md](https://github.com/bcgov/sfts2s3/blob/GDXDSD-5928-2nd-prep-for-archive/README.md)